### PR TITLE
Update versions

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  alias = "route53"
-}
-
-provider "aws" {
-  alias = "acm"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -3,6 +3,10 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4"
+      configuration_aliases = [
+        aws.acm,
+        aws.route53,
+      ]
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
   required_providers {
-    aws = "~> 3.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4"
+    }
   }
 
-  required_version = ">= 0.12.6"
+  required_version = ">= 1.0"
 }


### PR DESCRIPTION
- Update required versions
- Fix -> Warning: Empty provider configuration blocks are not required